### PR TITLE
 Use RubyVM::InstructionSequence.compile instead of open3

### DIFF
--- a/benchmark/ruby_wc
+++ b/benchmark/ruby_wc
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'benchmark/ips'
+require 'language_server'
+
+error_code = <<-EOS
+require "foo
+if a == "\\n"
+EOS
+warn_code = <<-EOS
+a = 1
+EOS
+valid_code = File.read(__FILE__)
+
+Benchmark.ips do |x|
+  x.report do
+    [error_code, warn_code, valid_code].each do |code|
+      LanguageServer::Linter::RubyWC.new(code).call
+    end
+  end
+end

--- a/language_server.gemspec
+++ b/language_server.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-power_assert"
   spec.add_development_dependency "m"
   spec.add_development_dependency "awesome_print"
+  spec.add_development_dependency "benchmark-ips"
 end

--- a/lib/language_server/linter/ruby_wc.rb
+++ b/lib/language_server/linter/ruby_wc.rb
@@ -1,4 +1,4 @@
-require "open3"
+require "stringio"
 
 module LanguageServer
   module Linter
@@ -26,11 +26,54 @@ module LanguageServer
       end
 
       def call
-        _, err, _ = Open3.capture3("ruby -wc", stdin_data: @source)
-
-        err.scan(/.+:(\d+):\s*(.+?)[,:]\s(.+)/).map do |line_num, type,  message|
+        error_message.scan(/.+:(\d+):\s*(.+?)[,:]\s(.+)/).map do |line_num, type,  message|
           Error.new(line_num: line_num.to_i - 1, message: message, type: type)
         end
+      end
+
+      private
+
+      # Since Ruby 2.4, syntax error information is outputted to Exception#message instead of stderr
+      if begin; stderr = $stderr; $stderr = StringIO.new; RubyVM::InstructionSequence.compile('='); rescue SyntaxError => e; e.message != 'compile error'; ensure; $stderr = stderr; end
+        def error_message
+          with_verbose do
+            begin
+              capture_stderr { RubyVM::InstructionSequence.compile(@source) }
+            rescue SyntaxError => e
+              e.message
+            end
+          end
+        end
+      else
+        def error_message
+          with_verbose do
+            capture_stderr do
+              begin
+                RubyVM::InstructionSequence.compile(@source)
+              rescue SyntaxError
+              end
+            end
+          end
+        end
+      end
+
+      def with_verbose
+        origin = $VERBOSE
+        $VERBOSE = true
+        yield
+      ensure
+        $VERBOSE = origin
+      end
+
+      def capture_stderr
+        origin = $stderr
+        $stderr = StringIO.new
+
+        yield
+
+        $stderr.string
+      ensure
+        $stderr = origin
       end
     end
   end


### PR DESCRIPTION
Close https://github.com/mtsmfm/language_server-ruby/issues/28

## Before

```
Warming up --------------------------------------
                         1.000  i/100ms
Calculating -------------------------------------
                         10.343  (± 9.7%) i/s -     52.000  in   5.072126s
```

## After

```
Warming up --------------------------------------
                       999.000  i/100ms
Calculating -------------------------------------
                         12.964k (±11.3%) i/s -     64.935k in   5.083127s
```