### PR TITLE
Fix an error that occurs during Definition

### DIFF
--- a/lib/language_server.rb
+++ b/lib/language_server.rb
@@ -67,6 +67,7 @@ module LanguageServer
   end
 
   on :initialize do |request:, variables:|
+    $LOAD_PATH << request[:params][:rootPath] if $LOAD_PATH
     variables[:file_store] = FileStore.new(load_paths: $LOAD_PATH, remote_root: request[:params][:rootPath], local_root: Dir.getwd)
     variables[:project] = Project.new(variables[:file_store])
 


### PR DESCRIPTION
The following error message always appears on the output of vs code when I select [go to definition] or [show definitions] with the file of my project in editor pane.

```
/app/lib/language_server/project.rb:15:in `find_definitions': undefined method `refs' for nil:NilClass (NoMethodError)
	from /app/lib/language_server/definition_provider/ad_hoc.rb:12:in `call'
	from /app/lib/language_server.rb:139:in `each'
	from /app/lib/language_server.rb:139:in `flat_map'
	from /app/lib/language_server.rb:139:in `block in <module:LanguageServer>'
	from /app/lib/language_server.rb:45:in `block in run'
	from /vendor/bundle/2.3.4/gems/language_server-protocol-0.4.0/lib/language_server/protocol/transport/stdio/reader.rb:27:in `read'
	from /app/lib/language_server.rb:34:in `run'
	from /app/exe/language_server-ruby:8:in `<top (required)>'
	from bin/language_server-ruby:8:in `load'
	from bin/language_server-ruby:8:in `<main>'
```

I think it happens because my project directory is out of scope.
That seems good to me adding the project root directory to the load path in the initialization process.

What do you think?